### PR TITLE
Update required gmail servers in /etc/exim4/passwd.client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2948,6 +2948,7 @@ Also, as discussed in [issue #29](https://github.com/imthenachoman/How-To-Secure
 1. Add a line like this to `/etc/exim4/passwd.client`
 
     ```
+    smtp.gmail.com:yourAccount@gmail.com:yourPassword
     *.google.com:yourAccount@gmail.com:yourPassword
     ```
 


### PR DESCRIPTION
As of October 2019, GMail appears to have switched its SMTP host from *.google.com to smtp.gmail.com (see [this support thread](https://support.google.com/mail/thread/16940173?hl=en)).

Added required line in exim4 password config to handle this change.