### PR TITLE
Changed the order of settings in #iptables-intrusion-detection-and-pr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1683,10 +1683,10 @@ And, since we're already using [UFW](#ufw-uncomplicated-firewall) so we'll follo
    |--|--|
    |[`EMAIL_ADDRESSES`](http://www.cipherdyne.org/psad/docs/config.html#EMAIL_ADDRESSES)|your email address(s)|
    |`HOSTNAME`|your server's hostname|
+   |`EXPECT_TCP_OPTIONS`|`EXPECT_TCP_OPTIONS Y;`|
    |`ENABLE_PSADWATCHD`|`ENABLE_PSADWATCHD Y;`|
    |[`ENABLE_AUTO_IDS`](http://www.cipherdyne.org/psad/docs/config.html#ENABLE_AUTO_IDS)|`ENABLE_AUTO_IDS Y;`|
    |`ENABLE_AUTO_IDS_EMAILS`|`ENABLE_AUTO_IDS_EMAILS Y;`|
-   |`EXPECT_TCP_OPTIONS`|`EXPECT_TCP_OPTIONS Y;`|
 
    Check the configuration file psad's documentation at http://www.cipherdyne.org/psad/docs/config.html for more details.
 


### PR DESCRIPTION
…evention-with-psad

When looking for these settings, EXPECT_TCP_OPTIONS was between HOSTNAME and ENABLE_PSADWATCHD in the file, but this guide put it at the end of the list. Changing that so that it's more consistent