### PR TITLE
Add crowdsec section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2161,6 +2161,7 @@ By default whilst CrowdSec is installing the Security Engine it will auto-discov
 > If your installation of UFW is not using `iptables` as the backend, you can alternatively install `crowdsec-firewall-bouncer-nftables`. There is no difference in the installed binaries, only the configuration file is different.
 
 By default whilst the Remediation Component is installing it will auto-configure the necessary settings to work with the Security Engine if deployed on the same host (and if the security engine is not within a container environment).
+
 3. Check detection and remediation is working as intended:
 
     CrowdSec package comes with a CLI tool to check the status of the Security Engine and the Remediation Component.

--- a/README.md
+++ b/README.md
@@ -2152,7 +2152,6 @@ By default whilst CrowdSec is installing the Security Engine it will auto-discov
 2. Install a Remediation Component. (IPS)
 
     CrowdSec by itself is a detection engine, since in most modern infrastructures you may have an upstream firewall or WAF, CrowdSec will not block the IP addresses by itself. You can install a Remediation Component to block the IP addresses detected by CrowdSec.
-
     ```bash
     sudo apt install crowdsec-firewall-bouncer-iptables
     ```
@@ -2237,7 +2236,7 @@ By default whilst the Remediation Component is installing it will auto-configure
     ╭──────────────────────────────────────────────────┬────────────┬────────┬──────╮
     │ Machine                                          │ Route      │ Method │ Hits │
     ├──────────────────────────────────────────────────┼────────────┼────────┼──────┤
-    │ githubciXXXXXXXXXXXXXXXXXXXXXXXXMKwkERgwSCD4NchX │ /v1/alerts │ GET    │ 2    │
+    │ <your_machine_id_will_be_here>                   │ /v1/alerts │ GET    │ 2    │
     ╰──────────────────────────────────────────────────┴────────────┴────────┴──────╯
 
     Parser Metrics:

--- a/README.md
+++ b/README.md
@@ -2156,14 +2156,11 @@ By default whilst CrowdSec is installing the Security Engine it will auto-discov
     ```bash
     sudo apt install crowdsec-firewall-bouncer-iptables
     ```
-    
-    By default whilst the Remediation Component is installing it will auto-configure the necessary settings to work with the Security Engine if deployed on the same host (and if the security engine is not within a container environment).
-
 
 > ![!TIP]
 > If your installation of UFW is not using `iptables` as the backend, you can alternatively install `crowdsec-firewall-bouncer-nftables`. There is no difference in the installed binaries, only the configuration file is different.
 
-
+By default whilst the Remediation Component is installing it will auto-configure the necessary settings to work with the Security Engine if deployed on the same host (and if the security engine is not within a container environment).
 3. Check detection and remediation is working as intended:
 
     CrowdSec package comes with a CLI tool to check the status of the Security Engine and the Remediation Component.

--- a/README.md
+++ b/README.md
@@ -2280,7 +2280,7 @@ To unban an IP use this command:
 cscli decisions delete --ip [IP]
 ```
 
-`[IP]` is the IP address you want to unban. For example, to unaban `192.168.1.100` from SSH you would do:
+`[IP]` is the IP address you want to unban. For example, to unban `192.168.1.100` from SSH you would do:
 
 ``` bash
 cscli decisions delete --ip 192.168.1.100

--- a/README.md
+++ b/README.md
@@ -2156,7 +2156,7 @@ By default whilst CrowdSec is installing the Security Engine it will auto-discov
     sudo apt install crowdsec-firewall-bouncer-iptables
     ```
 
-> ![!TIP]
+> [!TIP]
 > If your installation of UFW is not using `iptables` as the backend, you can alternatively install `crowdsec-firewall-bouncer-nftables`. There is no difference in the installed binaries, only the configuration file is different.
 
 By default whilst the Remediation Component is installing it will auto-configure the necessary settings to work with the Security Engine if deployed on the same host (and if the security engine is not within a container environment).

--- a/README.md
+++ b/README.md
@@ -2139,8 +2139,8 @@ CrowdSec monitors the logs of your applications (like SSH and Apache) to detect 
     curl -s https://install.crowdsec.net | sudo sh
     ```
     
-    > [!TIP]
-    > if `curl | sh` is not your thing, you can find additional install methods [here](https://docs.crowdsec.net/u/getting_started/installation/linux).
+> [!TIP]
+> if `curl | sh` is not your thing, you can find additional install methods [here](https://docs.crowdsec.net/u/getting_started/installation/linux).
 
     Install the CrowdSec Security Engine:
     ``` bash
@@ -2157,8 +2157,8 @@ By default whilst CrowdSec is installing the Security Engine it will auto-discov
     sudo apt install crowdsec-firewall-bouncer-iptables
     ```
 
-    > ![!TIP]
-    > If your installation of UFW is not using `iptables` as the backend, you can alternatively install `crowdsec-firewall-bouncer-nftables`. There is no difference in the installed binaries, only the configuration file is different.
+> ![!TIP]
+> If your installation of UFW is not using `iptables` as the backend, you can alternatively install `crowdsec-firewall-bouncer-nftables`. There is no difference in the installed binaries, only the configuration file is different.
 
 By default whilst the Remediation Component is installing it will auto-configure the necessary settings to work with the Security Engine if deployed on the same host (and if the security engine is not within a container environment).
 

--- a/README.md
+++ b/README.md
@@ -2138,14 +2138,14 @@ CrowdSec monitors the logs of your applications (like SSH and Apache) to detect 
     ``` bash
     curl -s https://install.crowdsec.net | sudo sh
     ```
-    
-> [!TIP]
-> if `curl | sh` is not your thing, you can find additional install methods [here](https://docs.crowdsec.net/u/getting_started/installation/linux).
 
     Install the CrowdSec Security Engine:
     ``` bash
     sudo apt install crowdsec
     ```
+
+> [!TIP]
+> if `curl | sh` is not your thing, you can find additional install methods [here](https://docs.crowdsec.net/u/getting_started/installation/linux).
 
 By default whilst CrowdSec is installing the Security Engine it will auto-discover your installed applications and install the appropriate parsers and scenarios for them. Since we know most Linux servers are running ssh out of the box CrowdSec will automatically configured this for you.
 

--- a/README.md
+++ b/README.md
@@ -2156,12 +2156,13 @@ By default whilst CrowdSec is installing the Security Engine it will auto-discov
     ```bash
     sudo apt install crowdsec-firewall-bouncer-iptables
     ```
+    
+    By default whilst the Remediation Component is installing it will auto-configure the necessary settings to work with the Security Engine if deployed on the same host (and if the security engine is not within a container environment).
 
 
 > ![!TIP]
 > If your installation of UFW is not using `iptables` as the backend, you can alternatively install `crowdsec-firewall-bouncer-nftables`. There is no difference in the installed binaries, only the configuration file is different.
 
-By default whilst the Remediation Component is installing it will auto-configure the necessary settings to work with the Security Engine if deployed on the same host (and if the security engine is not within a container environment).
 
 3. Check detection and remediation is working as intended:
 

--- a/README.md
+++ b/README.md
@@ -2157,6 +2157,7 @@ By default whilst CrowdSec is installing the Security Engine it will auto-discov
     sudo apt install crowdsec-firewall-bouncer-iptables
     ```
 
+
 > ![!TIP]
 > If your installation of UFW is not using `iptables` as the backend, you can alternatively install `crowdsec-firewall-bouncer-nftables`. There is no difference in the installed binaries, only the configuration file is different.
 


### PR DESCRIPTION
Fix: #77 

Here is a similar section to `fail2ban` that covers CrowdSec an alternative to the former. It describes how to install `CrowdSec` and a Remediation Component, since CrowdSec is built with cloud native in mind we decoupled the IDS and IPS component so there is 2 software packages to install.

Let me know your thoughts!