### PR TITLE
Fix broken link in PSAD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1871,7 +1871,7 @@ And, since we're already using [UFW](#ufw-uncomplicated-firewall) so we'll follo
     -A FORWARD -j LOG --log-tcp-options --log-prefix "[IPTABLES] "
     ```
 
-    **Note**: We're adding a log prefix to all the iptables logs. We'll need this for [seperating iptables logs to their own file](#ns-separate-iptables-log-file).
+    **Note**: We're adding a log prefix to all the iptables logs. We'll need this for [seperating iptables logs to their own file](#separate-iptables-log-file).
 
     For example:
 


### PR DESCRIPTION
Fixed a broken link in the "Iptables Intrusion Detection And Prevention with PSAD" section which should point to the later section of the guide "Separate iptables Log File".