### PR TITLE
Update SSH Compression recommendation to reflect modern OpenSSH behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,11 @@ SSH is a door into your server. This is especially true if you are opening ports
     # verify hostname matches IP
     UseDNS yes
 
-    Compression no
+    # OpenSSH only supports delayed (post-authentication) compression since
+    # 6.7, and removed pre-auth compression support entirely in 7.4 (2016),
+    # so the old compression-oracle attack surface this setting guarded
+    # against no longer exists on any currently supported OpenSSH version
+    Compression yes
     
     # TCP keepalive is spoofable (runs outside the encrypted channel)
 	# Use ClientAlive instead (runs inside the encrypted channel)


### PR DESCRIPTION
## Summary

- Updates the `Compression` recommendation in `sshd_config` from `no` to `yes`, with a comment explaining why.
- OpenSSH moved to delayed (post-authentication) compression by default in 6.7, and removed pre-authentication compression support entirely in 7.4 (2016). The compression-oracle attack surface that motivated the original `Compression no` recommendation no longer exists on any currently supported OpenSSH version.

Fixes #117

## References

- https://www.openssh.com/txt/release-6.7 — delayed compression became the default
- https://www.openssh.com/txt/release-7.4 — pre-auth compression support removed